### PR TITLE
Add LLM-driven job match analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Instructions
+- Do not add inline comments or docstrings.
+- Prefer pure functions and keep side effects explicit.

--- a/cursorrules
+++ b/cursorrules
@@ -1,0 +1,2 @@
+no-comments
+respect-user-instructions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 pymupdf
 requests
 python-dotenv
-scikit-learn    
+scikit-learn
 sentence-transformers
 spacy
-en_core_web_sm 
+en_core_web_sm
+openai
+groq

--- a/src/llm_analysis.py
+++ b/src/llm_analysis.py
@@ -1,0 +1,128 @@
+import os
+from typing import Dict, List, Optional
+
+try:
+    from openai import OpenAI
+except ImportError:
+    OpenAI = None
+
+try:
+    from groq import Groq
+except ImportError:
+    Groq = None
+
+SYSTEM_PROMPT = "You are an expert career coach who writes concise, structured compatibility analyses. Highlight strengths, potential gaps, and actionable advice."
+
+
+def _select_provider(preferred: Optional[str] = None) -> str:
+    if preferred:
+        return preferred
+    env_value = os.getenv("JOBMATCH_LLM_PROVIDER")
+    if env_value:
+        return env_value
+    if os.getenv("OPENAI_API_KEY"):
+        return "openai"
+    if os.getenv("GROQ_API_KEY"):
+        return "groq"
+    return ""
+
+
+def _build_profile_block(profile: Dict) -> str:
+    parts: List[str] = []
+    name = profile.get("name")
+    if name:
+        parts.append(f"Name: {name}")
+    headline = profile.get("headline")
+    if headline:
+        parts.append(f"Headline: {headline}")
+    for field in ["skills", "experience", "education", "certifications", "projects", "languages"]:
+        values = profile.get(field)
+        if values:
+            joined = " | ".join(values)
+            parts.append(f"{field.title()}: {joined}")
+    return "\n".join(parts)
+
+
+def _build_job_block(job: Dict) -> str:
+    parts: List[str] = []
+    title = job.get("job_title")
+    if title:
+        parts.append(f"Title: {title}")
+    company = job.get("employer_name")
+    if company:
+        parts.append(f"Company: {company}")
+    location = job.get("job_city")
+    if location:
+        parts.append(f"Location: {location}")
+    description = job.get("job_description")
+    if description:
+        parts.append(f"Description: {description}")
+    return "\n".join(parts)
+
+
+def _call_openai(prompt: str, model: Optional[str]) -> str:
+    if OpenAI is None:
+        raise RuntimeError("openai package not available")
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY missing")
+    client = OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model=model or os.getenv("JOBMATCH_OPENAI_MODEL", "gpt-4o-mini"),
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.2,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def _call_groq(prompt: str, model: Optional[str]) -> str:
+    if Groq is None:
+        raise RuntimeError("groq package not available")
+    api_key = os.getenv("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError("GROQ_API_KEY missing")
+    client = Groq(api_key=api_key)
+    response = client.chat.completions.create(
+        model=model or os.getenv("JOBMATCH_GROQ_MODEL", "llama3-70b-8192"),
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.2,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def analyze_match(profile: Dict, job: Dict, provider: Optional[str] = None, model: Optional[str] = None) -> Optional[str]:
+    selected = _select_provider(provider)
+    if not selected:
+        return None
+    profile_text = _build_profile_block(profile)
+    job_text = _build_job_block(job)
+    if not profile_text or not job_text:
+        return None
+    prompt = (
+        "Candidate Profile:\n"
+        + profile_text
+        + "\n\nJob Posting:\n"
+        + job_text
+        + "\n\nProvide a short compatibility analysis with bullet points for strengths, gaps, and tailored recommendations."
+    )
+    if selected.lower() == "openai":
+        return _call_openai(prompt, model)
+    if selected.lower() == "groq":
+        return _call_groq(prompt, model)
+    return None
+
+
+def analyze_matches(profile: Dict, jobs: List[Dict], provider: Optional[str] = None, model: Optional[str] = None) -> List[Optional[str]]:
+    results: List[Optional[str]] = []
+    for job in jobs:
+        try:
+            results.append(analyze_match(profile, job, provider, model))
+        except Exception:
+            results.append(None)
+    return results

--- a/src/run_match.py
+++ b/src/run_match.py
@@ -1,17 +1,16 @@
 from parse_profile import extract_text_from_pdf, parse_profile
 from match_jobs import match_profile_to_jobs
 from job_search import query_and_save_jobs
+from llm_analysis import analyze_matches
 import json
 
 if __name__ == "__main__":
-    # 1. Extract & parse profile
     text = extract_text_from_pdf("data/linkedin_profile.pdf")
     profile = parse_profile(text)
-    
+
     with open("data/linkedin_profile.json", "w") as f:
         json.dump(profile, f, indent=4)
 
-    # 2. Fetch jobs and load from file
     query_and_save_jobs(query="berlin nlp data scientist ")
 
     with open("data/job_postings.json") as f:
@@ -31,15 +30,9 @@ if __name__ == "__main__":
 
     job_postings = filtered_jobs
 
-    # 3. Match
-    job_terms_list = [
-        job.get('job_title', '') + ' ' + job.get('job_description', '')
-        for job in job_postings
-    ]
+    top_matches = match_profile_to_jobs(profile, job_postings, top_n=3)
+    insights = analyze_matches(profile, top_matches)
 
-    top_matches = match_profile_to_jobs(profile, job_postings, job_terms_list, top_n=3)
-
-    # 4. Display
     for i, job in enumerate(top_matches, 1):
         print(f"\n🔹 Match #{i}")
         print(f"Title: {job['job_title']}")
@@ -47,3 +40,7 @@ if __name__ == "__main__":
         print(f"Location: {job.get('job_city', 'N/A')}")
         print(f"Description: {job.get('job_description', 'N/A')[:300]}...")
         print(f"Apply Link: {job.get('job_apply_link', 'N/A')}")
+        insight = insights[i - 1]
+        if insight:
+            print("LLM Insight:")
+            print(insight)


### PR DESCRIPTION
## Summary
- add an llm_analysis module that can call OpenAI GPT-4 or Groq Llama 3 models for job-fit insights
- update the matching workflow to surface model-generated feedback alongside top job matches
- include the new client libraries in project requirements and document repo rules

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d43fb928a0832e83b9162ac3b28397